### PR TITLE
add gradient overlays

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
 }

--- a/pages/api/og/nyt.tsx
+++ b/pages/api/og/nyt.tsx
@@ -32,13 +32,33 @@ export default async function handler(req: NextRequest) {
           flexDirection: "column",
           alignItems: "flex-start",
           justifyContent: "center",
-          backgroundImage: `url(${image})`,
-          backgroundRepeat: "no-repeat",
-          backgroundSize: "cover",
           fontWeight: 600,
           color: "white",
         }}
       >
+        <img
+          src={image}
+          alt=""
+          width={1050}
+          height={549} 
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            height: "66%",
+            width: "100%",
+            background:
+              "linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,1) 100%)",
+          }}
+        ></div>
         <h1
           style={{
             position: "absolute",

--- a/pages/api/og/nyt.tsx
+++ b/pages/api/og/nyt.tsx
@@ -58,7 +58,7 @@ export default async function handler(req: NextRequest) {
             background:
               "linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,1) 100%)",
           }}
-        ></div>
+        />
         <h1
           style={{
             position: "absolute",

--- a/pages/api/og/nyt.tsx
+++ b/pages/api/og/nyt.tsx
@@ -40,7 +40,7 @@ export default async function handler(req: NextRequest) {
           src={image}
           alt=""
           width={1050}
-          height={549} 
+          height={549}
           style={{
             width: "100%",
             height: "100%",

--- a/pages/api/og/tc.tsx
+++ b/pages/api/og/tc.tsx
@@ -58,7 +58,7 @@ export default async function handler(req: NextRequest) {
             background:
               "linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,1) 100%)",
           }}
-        ></div>
+        />
         <h1
           style={{
             position: "absolute",

--- a/pages/api/og/tc.tsx
+++ b/pages/api/og/tc.tsx
@@ -22,6 +22,9 @@ export default async function handler(req: NextRequest) {
     `https://api.dub.co/metatags?url=${url}`
   ).then((res) => res.json());
 
+  console.log(url, title, image
+    )
+
   return new ImageResponse(
     (
       <div
@@ -32,37 +35,49 @@ export default async function handler(req: NextRequest) {
           flexDirection: "column",
           alignItems: "flex-start",
           justifyContent: "center",
-          backgroundImage: `url(${image})`,
-          backgroundRepeat: "no-repeat",
-          backgroundSize: "cover",
           fontWeight: 600,
           color: "white",
         }}
       >
+        <img
+          src={image}
+          alt=""
+          width={1050}
+          height={549} 
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+          }}
+        />
         <div
           style={{
-            display: "flex",
             position: "absolute",
             bottom: 0,
             left: 0,
+            height: "66%",
             width: "100%",
-            padding: "20px 80px",
-            backgroundColor: "white",
+            background:
+              "linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,1) 100%)",
+          }}
+        ></div>
+        <h1
+          style={{
+            position: "absolute",
+            bottom: 60,
+            left: 60,
+            right: 60,
+            fontSize: 50,
+            fontFamily: "Aktiv Grotesk",
+            color: "white",
+            maxWidth: 900,
+            whiteSpace: "pre-wrap",
+            lineHeight: 1.4,
           }}
         >
-          <h1
-            style={{
-              fontSize: 50,
-              fontFamily: "Aktiv Grotesk",
-              color: "black",
-              maxWidth: 900,
-              whiteSpace: "pre-wrap",
-              lineHeight: 1.4,
-            }}
-          >
-            {title.replace(" | TechCrunch", "")}
-          </h1>
-        </div>
+          {title.replace(" | TechCrunch", "")}
+        </h1>
       </div>
     ),
     {

--- a/pages/api/og/tc.tsx
+++ b/pages/api/og/tc.tsx
@@ -22,9 +22,6 @@ export default async function handler(req: NextRequest) {
     `https://api.dub.co/metatags?url=${url}`
   ).then((res) => res.json());
 
-  console.log(url, title, image
-    )
-
   return new ImageResponse(
     (
       <div
@@ -43,7 +40,7 @@ export default async function handler(req: NextRequest) {
           src={image}
           alt=""
           width={1050}
-          height={549} 
+          height={549}
           style={{
             width: "100%",
             height: "100%",

--- a/pages/api/og/wired.tsx
+++ b/pages/api/og/wired.tsx
@@ -32,13 +32,33 @@ export default async function handler(req: NextRequest) {
           flexDirection: "column",
           alignItems: "flex-start",
           justifyContent: "center",
-          backgroundImage: `url(${image})`,
-          backgroundRepeat: "no-repeat",
-          backgroundSize: "cover",
           fontWeight: 600,
           color: "white",
         }}
       >
+        <img
+          src={image}
+          alt=""
+          width={1050}
+          height={549} 
+          style={{
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            objectPosition: "center",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            height: "66%",
+            width: "100%",
+            background:
+              "linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,1) 100%)",
+          }}
+        ></div>
         <h1
           style={{
             position: "absolute",

--- a/pages/api/og/wired.tsx
+++ b/pages/api/og/wired.tsx
@@ -58,7 +58,7 @@ export default async function handler(req: NextRequest) {
             background:
               "linear-gradient(to bottom, rgba(0,0,0,0) 0%,rgba(0,0,0,1) 100%)",
           }}
-        ></div>
+        />
         <h1
           style={{
             position: "absolute",

--- a/pages/api/og/wired.tsx
+++ b/pages/api/og/wired.tsx
@@ -40,7 +40,7 @@ export default async function handler(req: NextRequest) {
           src={image}
           alt=""
           width={1050}
-          height={549} 
+          height={549}
           style={{
             width: "100%",
             height: "100%",


### PR DESCRIPTION
For [ogimage.org](https://ogimage.org), I used this idea to add gradient overlays for OG images. I started a PR here to add them: https://github.com/Illyism/ogimage.org/pull/1

As a way of thanks, I'll contribute back the code for adding gradient overlays. This fixes the issue:

- https://github.com/steven-tey/og/issues/2

# Techcrunch

Before:

<img width="560" alt="image" src="https://github.com/steven-tey/og/assets/304283/6894cdc9-6cff-4e9d-a6e3-e480f1b1cf43">


After:

<img width="565" alt="image" src="https://github.com/steven-tey/og/assets/304283/1b2b5e54-de7e-4279-81b5-52f356138e6c">

# Wired

Before:
<img width="561" alt="image" src="https://github.com/steven-tey/og/assets/304283/018b7221-f776-42de-8109-c7018f573708">


After:

<img width="557" alt="image" src="https://github.com/steven-tey/og/assets/304283/df36f43c-3ce8-43f4-b495-cc2663b08b53">

# NYT (default)

Before:

<img width="534" alt="image" src="https://github.com/steven-tey/og/assets/304283/d3e610cf-bd95-4485-bd27-d0116f3c03e5">


After:

<img width="543" alt="image" src="https://github.com/steven-tey/og/assets/304283/7b78957c-a1f4-4558-adbf-203beeeee725">
